### PR TITLE
Feat/124 request body

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -22,6 +22,11 @@
     "requestHeaders": {
       "headerKeyPlaceholder": "Header",
       "headerValuePlaceholder": "Value"
+    },
+    "requestBody": {
+      "prettifyButton": "Prettify",
+      "JSONPlaceholder": "Enter JSON",
+      "textPlaceholder": "Enter plain text"
     }
   },
   "NotFoundPage": {

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -22,6 +22,11 @@
     "requestHeaders": {
       "headerKeyPlaceholder": "Заголовок",
       "headerValuePlaceholder": "Значение"
+    },
+    "requestBody": {
+      "prettifyButton": "Форматировать",
+      "JSONPlaceholder": "Введите JSON",
+      "textPlaceholder": "Введите текст"
     }
   },
   "NotFoundPage": {

--- a/src/components/ClientPage/ClientPage.tsx
+++ b/src/components/ClientPage/ClientPage.tsx
@@ -9,6 +9,7 @@ import { HeaderItem } from '../RequestHeaders/RequestHeaders';
 import { forwardRequest, ServerResponse } from '@/lib/actions/request';
 import { v4 as uuidv4 } from 'uuid';
 import ResponseSection from '../ResponseSection/ResponseSection';
+import RequestBody from '../RequestBody/RequestBody';
 
 const initialHeaders: HeaderItem[] = [
   { id: uuidv4(), enabled: true, key: 'Content-Type', value: 'application/json' },
@@ -60,6 +61,7 @@ export default function ClientPage() {
             loading={loading}
           />
           <RequestHeaders headers={headers} setHeaders={setHeaders} />
+          <RequestBody />
         </section>
         <div className={classes.divider}></div>
         <section className={classes.panel}>

--- a/src/components/RequestBody/RequestBody.module.css
+++ b/src/components/RequestBody/RequestBody.module.css
@@ -1,0 +1,38 @@
+.container {
+  padding: 12px;
+  border-radius: 8px;
+  background: var(--white-color);
+}
+
+.controls {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: start;
+
+  margin-bottom: 8px;
+}
+
+.select {
+  padding: 0.1rem;
+  font-size: 14px;
+}
+
+.mono {
+  resize: vertical;
+
+  overflow: auto;
+
+  width: 100%;
+  height: 191px;
+  padding: 8px;
+  border: 1px solid var(--light-disabled-color);
+  border-radius: 4px;
+
+  font-family: monospace;
+  font-size: 14px;
+  line-height: 1.5;
+  white-space: pre;
+
+  outline: none;
+}

--- a/src/components/RequestBody/RequestBody.tsx
+++ b/src/components/RequestBody/RequestBody.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState } from 'react';
+import classes from './RequestBody.module.css';
+
+type BodyType = 'json' | 'text';
+
+type Props = {
+  readOnly?: boolean;
+};
+
+export default function RequestBody({ readOnly = false }: Props) {
+  const [value, setValue] = useState('');
+  const [bodyType, setBodyType] = useState<BodyType>('json');
+  return (
+    <>
+      <h3>Request body</h3>
+      <div className={classes.container}>
+        {!readOnly && (
+          <div className={classes.controls}>
+            <select
+              aria-label='Body mode'
+              value={bodyType}
+              className={classes.select}
+              onChange={(e) => setBodyType(e.target.value as BodyType)}
+            >
+              <option value='json'>JSON</option>
+              <option value='text'>Text</option>
+            </select>
+            {bodyType === 'json' && <button>Prettify</button>}
+          </div>
+        )}
+
+        {readOnly ? (
+          <pre className={classes.mono}>{value}</pre>
+        ) : (
+          <textarea
+            aria-label='Request body editor'
+            placeholder={bodyType === 'json' ? 'JSON' : 'Plain text'}
+            value={value}
+            onChange={(e) => {
+              setValue(e.target.value);
+            }}
+            className={classes.mono}
+          />
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/components/RequestBody/RequestBody.tsx
+++ b/src/components/RequestBody/RequestBody.tsx
@@ -27,7 +27,20 @@ export default function RequestBody({ readOnly = false }: Props) {
               <option value='json'>JSON</option>
               <option value='text'>Text</option>
             </select>
-            {bodyType === 'json' && <button>Prettify</button>}
+            {bodyType === 'json' && (
+              <button
+                onClick={() => {
+                  try {
+                    const pretty = JSON.stringify(JSON.parse(value), null, 2);
+                    setValue(pretty);
+                  } catch {
+                    // TODO: add error handler
+                  }
+                }}
+              >
+                Prettify
+              </button>
+            )}
           </div>
         )}
 

--- a/src/components/RequestBody/RequestBody.tsx
+++ b/src/components/RequestBody/RequestBody.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import classes from './RequestBody.module.css';
+import { useTranslations } from 'next-intl';
 
 type BodyType = 'json' | 'text';
 
@@ -10,6 +11,8 @@ type Props = {
 };
 
 export default function RequestBody({ readOnly = false }: Props) {
+  const t = useTranslations('ClientPage.requestBody');
+
   const [value, setValue] = useState('');
   const [bodyType, setBodyType] = useState<BodyType>('json');
   return (
@@ -38,7 +41,7 @@ export default function RequestBody({ readOnly = false }: Props) {
                   }
                 }}
               >
-                Prettify
+                {t('prettifyButton')}
               </button>
             )}
           </div>
@@ -49,7 +52,7 @@ export default function RequestBody({ readOnly = false }: Props) {
         ) : (
           <textarea
             aria-label='Request body editor'
-            placeholder={bodyType === 'json' ? 'JSON' : 'Plain text'}
+            placeholder={bodyType === 'json' ? t('JSONPlaceholder') : t('textPlaceholder')}
             value={value}
             onChange={(e) => {
               setValue(e.target.value);

--- a/src/components/RequestHeaders/RequestHeaders.module.css
+++ b/src/components/RequestHeaders/RequestHeaders.module.css
@@ -31,9 +31,12 @@
 }
 
 .table {
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 4px;
+
+  height: 170px;
 }
 
 .row {


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] 🚀 Feature
- [ ] 🧹 Refactor
- [ ] 🪲 Bug Fix
- [ ] 📝 Tests
- [ ] 📖 Docs update
- [ ] 🛠️ Chore

## Description

- Add body request layout. It supports `text` and `JSON` formats.
- Add `prettify` button for `JSON`

## Rationale

Users should be able to add request body

## Related Tasks & Issues

- Closes #124 

## Screenshot (optional)
<img width="794" height="396" alt="image" src="https://github.com/user-attachments/assets/2bfcef46-a2b4-447f-b9ed-7cff35e18c5c" />
<img width="782" height="391" alt="image" src="https://github.com/user-attachments/assets/2e1f6dc8-7981-4755-a8b0-5b05dc0bb8d0" />
<img width="779" height="376" alt="image" src="https://github.com/user-attachments/assets/8fab1298-85c4-4f9c-8006-52b7fdf7c69a" />
